### PR TITLE
Adding Byte/String Searches

### DIFF
--- a/hexforge_modules/helper.py
+++ b/hexforge_modules/helper.py
@@ -1,6 +1,7 @@
 import idaapi
 import idc
-
+import ida_hexrays
+import ida_kernwin
 # IDA python functions
 
 
@@ -34,6 +35,20 @@ def write_bytes_to_selected(data) -> None:
         for i, x in enumerate(data):
             idaapi.patch_byte(start + i, x)
 
+def get_highighted_string_from_decompiler() -> str:
+    """
+    Get the highlighted string from the decompiler view in IDA Pro.
+
+    :return: The highlighted string or an empty string if no text is highlighted.
+    """
+    widget = ida_kernwin.get_current_widget()
+    if widget and ida_kernwin.get_widget_type(widget) == ida_kernwin.BWN_PSEUDOCODE:
+        vu = ida_hexrays.get_widget_vdui(widget)
+        if vu:
+            highlighted_text = ida_kernwin.get_highlight(vu.ct)
+            if highlighted_text:
+                return highlighted_text[0]
+    return ""
 
 # Template class for modules
 class ModuleTemplate:

--- a/hexforge_modules/helper.py
+++ b/hexforge_modules/helper.py
@@ -35,7 +35,7 @@ def write_bytes_to_selected(data) -> None:
         for i, x in enumerate(data):
             idaapi.patch_byte(start + i, x)
 
-def get_highighted_string_from_decompiler() -> str:
+def get_highlighted_string_from_decompiler() -> str:
     """
     Get the highlighted string from the decompiler view in IDA Pro.
 

--- a/hexforge_modules/search.py
+++ b/hexforge_modules/search.py
@@ -14,7 +14,7 @@ class SearchGoogle(helper.ModuleTemplate):
 
     def _action(self) -> None:
 
-        data = helper.get_highighted_string_from_decompiler()
+        data = helper.get_highlighted_string_from_decompiler()
         try:
             formatted_url = f"https://www.google.com/search?q={data}"
             ida_kernwin.open_url(formatted_url)
@@ -31,7 +31,7 @@ class SearchGitHub(helper.ModuleTemplate):
 
     def _action(self) -> None:
 
-        data = helper.get_highighted_string_from_decompiler()
+        data = helper.get_highlighted_string_from_decompiler()
         try:
             formatted_url = f"https://github.com/search?q={data}&type=code"
             ida_kernwin.open_url(formatted_url)
@@ -48,7 +48,7 @@ class SearchGrepApp(helper.ModuleTemplate):
 
     def _action(self) -> None:
 
-        data = helper.get_highighted_string_from_decompiler()
+        data = helper.get_highlighted_string_from_decompiler()
         try:
             formatted_url = f"https://grep.app/search?q={data}"
             ida_kernwin.open_url(formatted_url)
@@ -83,7 +83,7 @@ class SearchVirustotalString(helper.ModuleTemplate):
 
     def _action(self) -> None:
 
-        data = helper.get_highighted_string_from_decompiler()
+        data = helper.get_highlighted_string_from_decompiler()
         try:
             formatted_url = f"https://www.virustotal.com/gui/search/content%253A%2520{data}"
             ida_kernwin.open_url(formatted_url)

--- a/hexforge_modules/search.py
+++ b/hexforge_modules/search.py
@@ -1,0 +1,95 @@
+import ida_kernwin
+import idaapi
+import binascii
+import re
+
+from hexforge_modules import helper
+
+
+class SearchGoogle(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::search_google_string"
+        self.ACTION_TEXT = "search string in Google"
+        self.ACTION_TOOLTIP = "search string in Google"
+
+    def _action(self) -> None:
+
+        data = helper.get_highighted_string_from_decompiler()
+        try:
+            formatted_url = f"https://www.google.com/search?q={data}"
+            ida_kernwin.open_url(formatted_url)
+            
+        except Exception as e:
+            print(e)
+            return None
+        
+class SearchGitHub(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::search_github"
+        self.ACTION_TEXT = "search string in GitHub"
+        self.ACTION_TOOLTIP = "search string in GitHub"
+
+    def _action(self) -> None:
+
+        data = helper.get_highighted_string_from_decompiler()
+        try:
+            formatted_url = f"https://github.com/search?q={data}&type=code"
+            ida_kernwin.open_url(formatted_url)
+            
+        except Exception as e:
+            print(e)
+            return None
+
+class SearchGrepApp(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::search_grepapp_string"
+        self.ACTION_TEXT = "search string in Grep.app"
+        self.ACTION_TOOLTIP = "search string in Grep.app"
+
+    def _action(self) -> None:
+
+        data = helper.get_highighted_string_from_decompiler()
+        try:
+            formatted_url = f"https://grep.app/search?q={data}"
+            ida_kernwin.open_url(formatted_url)
+            
+        except Exception as e:
+            print(e)
+            return None
+        
+class SearchVirustotalBytes(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::search_virustotal_bytes"
+        self.ACTION_TEXT = "search bytes in VirusTotal"
+        self.ACTION_TOOLTIP = "search bytes in VirusTotal"
+
+    def _action(self) -> None:
+
+        data = helper.get_selected_bytes()
+        try:
+            hex_data = binascii.hexlify(data).decode('utf-8')
+            formatted_url = f"https://www.virustotal.com/gui/search/content%253A%2520%257B{hex_data}%257D"
+            ida_kernwin.open_url(formatted_url)
+            
+        except (binascii.Error, UnicodeDecodeError) as e:
+            print(e)
+            return None
+        
+class SearchVirustotalString(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::search_virustotal_string"
+        self.ACTION_TEXT = "search string in VirusTotal"
+        self.ACTION_TOOLTIP = "search string in VirusTotal"
+
+    def _action(self) -> None:
+
+        data = helper.get_highighted_string_from_decompiler()
+        try:
+            formatted_url = f"https://www.virustotal.com/gui/search/content%253A%2520{data}"
+            ida_kernwin.open_url(formatted_url)
+            
+        except Exception as e:
+            print(e)
+            return None
+
+


### PR DESCRIPTION
**Overview**

Here's a PR that adds searching capabilities for different services based on bytes highlighted from the disassembler and strings highlighted from the decompiler. This includes:

**Disassembler**
  - Byte search in VirusTotal 
  
![image](https://github.com/user-attachments/assets/45464eef-78ef-49c4-acb4-20fa5f2ccf66)
![image](https://github.com/user-attachments/assets/79917bc5-54d6-4ef5-b404-83749bed45ae)

 **Decompiler**
  - String search in GitHub
  - String search in Google
  - String search in Grep.app
  - String search in VirusTotal
   
![image](https://github.com/user-attachments/assets/33d0847b-1d26-44cb-82c5-23575b15591b)
![image](https://github.com/user-attachments/assets/e2a5663f-089e-4144-826b-b135f71fd90b)


