### PR TITLE
Add Genome search module

### DIFF
--- a/hexforge_modules/search.py
+++ b/hexforge_modules/search.py
@@ -1,9 +1,17 @@
+import ida_bytes
+import ida_funcs
 import ida_kernwin
-import idaapi
+import idc
+
 import binascii
-import re
+import elasticsearch
+import tlsh
+import pathlib
 
 from hexforge_modules import helper
+
+
+DEFAULT_SCORE_THRESHOLD = 100
 
 
 class SearchGoogle(helper.ModuleTemplate):
@@ -18,11 +26,11 @@ class SearchGoogle(helper.ModuleTemplate):
         try:
             formatted_url = f"https://www.google.com/search?q={data}"
             ida_kernwin.open_url(formatted_url)
-            
+
         except Exception as e:
             print(e)
             return None
-        
+
 class SearchGitHub(helper.ModuleTemplate):
     def __init__(self):
         self.ACTION_NAME = "hexforge::search_github"
@@ -35,7 +43,7 @@ class SearchGitHub(helper.ModuleTemplate):
         try:
             formatted_url = f"https://github.com/search?q={data}&type=code"
             ida_kernwin.open_url(formatted_url)
-            
+
         except Exception as e:
             print(e)
             return None
@@ -52,11 +60,11 @@ class SearchGrepApp(helper.ModuleTemplate):
         try:
             formatted_url = f"https://grep.app/search?q={data}"
             ida_kernwin.open_url(formatted_url)
-            
+
         except Exception as e:
             print(e)
             return None
-        
+
 class SearchVirustotalBytes(helper.ModuleTemplate):
     def __init__(self):
         self.ACTION_NAME = "hexforge::search_virustotal_bytes"
@@ -70,11 +78,11 @@ class SearchVirustotalBytes(helper.ModuleTemplate):
             hex_data = binascii.hexlify(data).decode('utf-8')
             formatted_url = f"https://www.virustotal.com/gui/search/content%253A%2520%257B{hex_data}%257D"
             ida_kernwin.open_url(formatted_url)
-            
+
         except (binascii.Error, UnicodeDecodeError) as e:
             print(e)
             return None
-        
+
 class SearchVirustotalString(helper.ModuleTemplate):
     def __init__(self):
         self.ACTION_NAME = "hexforge::search_virustotal_string"
@@ -87,9 +95,81 @@ class SearchVirustotalString(helper.ModuleTemplate):
         try:
             formatted_url = f"https://www.virustotal.com/gui/search/content%253A%2520{data}"
             ida_kernwin.open_url(formatted_url)
-            
+
         except Exception as e:
             print(e)
             return None
 
 
+class GenomeModule(helper.ModuleTemplate):
+    def __init__(self):
+        self.ACTION_NAME = "hexforge::match_function"
+        self.ACTION_TEXT = "Match Function (VectorSearch)"
+        self.ACTION_TOOLTIP = "Match current function to known signatures using VectorSearch"
+
+        home = pathlib.Path().home()
+        cred_file = home / ".genome_es_credentials.txt"
+        lines = cred_file.read_text().splitlines()
+        es_cloud_id, es_api_key = lines[0], lines[1]
+        self.es = elasticsearch.Elasticsearch(
+            cloud_id=es_cloud_id,
+            api_key=es_api_key,
+        )
+
+    def _action(self) -> None:
+        from PyQt5.Qt import QApplication
+
+        ea = idc.get_screen_ea()
+        func = ida_funcs.get_func(ea)
+        if not func:
+            print("Failed to get function object")
+            return
+
+        func = ida_funcs.get_func(ea)
+        func_name = idc.get_func_name(func.start_ea)
+        start_ea = func.start_ea
+        end_ea = func.end_ea
+        func_size = end_ea - start_ea
+        func_bytes = ida_bytes.get_bytes(start_ea, func_size)
+        tlsh_hash = tlsh.hexdigest(func_bytes, 1)
+        print(f"Function {func_name} got TLSH={tlsh_hash}, looking up...")
+
+        vector = tlsh_hash[-64:]
+        lowest_size = round(0.90 * func_size)
+        highest_size = round(1.10 * func_size)
+
+        es_query = {
+            "field": "tlsh_vector",
+            "query_vector": vector,
+            "k": 5,
+            "num_candidates": 50,
+            "filter": [{"range": {"size": {"gt": lowest_size, "lt": highest_size}}}],
+        }
+        index_name = "genome-dataatoms-functions*"
+        matches = []
+
+        if True:
+            response = self.es.search(index=index_name, body={"knn": es_query})
+            hits = response.get("hits", {}).get("hits", [])
+            for hit in hits:
+                original_name = hit.get("_source", {}).get("name", "Unknown")
+                original_tlsh = hit.get("_source", {}).get("tlsh", "Unknown")
+
+                t1 = tlsh.Tlsh()
+                t1.load(tlsh_hash)
+                assert t1.valid
+                t2 = tlsh.Tlsh()
+                t2.load(original_tlsh)
+                assert t2.valid
+                diff_score = t1.diff(t2)
+                if diff_score > DEFAULT_SCORE_THRESHOLD:
+
+                    continue
+
+                matches.append((original_name, diff_score))
+
+        matches.sort(key=lambda x: x[1])
+        print(f"Found {len(matches)} matches")
+        symbol, score = matches[0]
+        print(f"Best match for {func_name} is {symbol} (score={score}, threshold={DEFAULT_SCORE_THRESHOLD})")
+        return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pycryptodome==3.20.0
+tlsh-python>=0.1.0
+elasticsearch>=8.16.0


### PR DESCRIPTION
## Description

This simple PR adds supports for search the current function with the data collected by [genome](/elastic/genome-rs) and stored an Elastic instance. This allows to use Vector Search for quickly identify functions against known functions whose TLSH signatures we have.

Note that this is a basic search (synchronous, no renaming etc.) but we can add more modules if desired - like already done with [genome-binja](/elastic/genome-binja).

![image](https://github.com/user-attachments/assets/09b266b4-cccb-47b0-9361-50cff1107896)

![image](https://github.com/user-attachments/assets/17e8506d-509b-427c-a54f-992b4e87d9e8)
